### PR TITLE
Add DefaultResponders

### DIFF
--- a/src/Seq.App.Opsgenie/OpsgenieApp.cs
+++ b/src/Seq.App.Opsgenie/OpsgenieApp.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
-using System.Collections.Generic;
 
 // ReSharper disable MemberCanBePrivate.Global, UnusedType.Global, UnusedAutoPropertyAccessor.Global
 
@@ -12,18 +12,22 @@ namespace Seq.App.Opsgenie
     [SeqApp("Opsgenie Alerting", Description = "Send Opsgenie alerts using the HTTP API.")]
     public class OpsgenieApp : SeqApp, IDisposable, ISubscribeToAsync<LogEventData>
     {
-        IDisposable _disposeClient;
-        HandlebarsTemplate _generateMessage, _generateDescription;
-        string _priorityProperty = "@Level";
-        bool _isPriorityMapping;
-        Priority _priority = Priority.P3, _defaultPriority = Priority.P3;
-        readonly Dictionary<string, Priority> _priorities = new Dictionary<string, Priority>(StringComparer.OrdinalIgnoreCase);
-        string _responderProperty;
-        bool _isResponderMapping;
-        readonly List<Responder> _responders = new List<Responder>();
-        string[] _tags;
-        bool _includeTags;
-        string _includeTagProperty;
+        private readonly List<Responder> _defaultResponders = new List<Responder>();
+
+        private readonly Dictionary<string, Priority> _priorities =
+            new Dictionary<string, Priority>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly List<Responder> _responders = new List<Responder>();
+        private IDisposable _disposeClient;
+        private HandlebarsTemplate _generateMessage, _generateDescription;
+        private string _includeTagProperty;
+        private bool _includeTags;
+        private bool _isPriorityMapping;
+        private bool _isResponderMapping;
+        private Priority _priority = Priority.P3, _defaultPriority = Priority.P3;
+        private string _priorityProperty = "@Level";
+        private string _responderProperty;
+        private string[] _tags;
 
         // Permits substitution for testing.
         internal IOpsgenieApiClient ApiClient { get; set; }
@@ -37,47 +41,61 @@ namespace Seq.App.Opsgenie
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Alert message",
-            HelpText = "The message associated with the alert, specified with Handlebars syntax. If blank, the message " +
-                       "from the incoming event or notification will be used.")]
+            HelpText =
+                "The message associated with the alert, specified with Handlebars syntax. If blank, the message " +
+                "from the incoming event or notification will be used.")]
         public string AlertMessage { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Alert description",
-            HelpText = "The description associated with the alert, specified with Handlebars syntax. If blank, a default" +
-                       " description will be used.")]
+            HelpText =
+                "The description associated with the alert, specified with Handlebars syntax. If blank, a default" +
+                " description will be used.")]
         public string AlertDescription { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Priority Property",
-            HelpText = "Optional property to read for alert priority (default @Level); properties can be mapped to OpsGenie priorities using the Alert Priority or Property Mapping field.")]
+            HelpText =
+                "Optional property to read for alert priority (default @Level); properties can be mapped to OpsGenie priorities using the Alert Priority or Property Mapping field.")]
         public string PriorityProperty { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Alert Priority or Property Mapping",
-            HelpText = "Priority for the alert - P1, P2, P3, P4, P5 - or 'Priority Property' mapping using Property=Mapping format - Highest=P1,Error=P2,Critical=P3.")]
+            HelpText =
+                "Priority for the alert - P1, P2, P3, P4, P5 - or 'Priority Property' mapping using Property=Mapping format - Highest=P1,Error=P2,Critical=P3.")]
         public string EventPriority { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Default Priority",
-            HelpText = "If using Priority Property Mapping - Default Priority for alerts not matching the mapping - P1, P2, P3, P4, P5. Defaults to P3.")]
+            HelpText =
+                "If using Priority Property Mapping - Default Priority for alerts not matching the mapping - P1, P2, P3, P4, P5. Defaults to P3.")]
         public string DefaultPriority { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Responder Property",
-            HelpText = "Optional property to read for responder; properties can be mapped to responder type using the Responders or Property Mapping field.")]
+            HelpText =
+                "Optional property to read for responder; properties can be mapped to responder type using the Responders or Property Mapping field.")]
         public string ResponderProperty { get; set; }
 
         //Defaults to team if only name is specified, but we also optionally accept name=type to allow user, escalation, and schedule to be specified
         [SeqAppSetting(
             IsOptional = true,
-            DisplayName = "Responders",
-            HelpText = "Responders for the alert - team name, or name=[team,user,escalation,schedule] - comma-delimited for multiple responder or property mapping.")]
+            DisplayName = "Responders or Property Mapping",
+            HelpText =
+                "Responders for the alert - team name, or name=[team,user,escalation,schedule] - comma-delimited for multiple responder or property mapping.")]
         public string Responders { get; set; }
+
+        [SeqAppSetting(
+            IsOptional = true,
+            DisplayName = "Default Responders",
+            HelpText =
+                "If using Responder Property Mapping - Default Responder names for alerts not matching the mapping. Comma-delimited for multiple responders.")]
+        public string DefaultResponders { get; set; }
 
         //Static list of tags
         [SeqAppSetting(
@@ -90,105 +108,21 @@ namespace Seq.App.Opsgenie
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Include event tags",
-            HelpText = "Include tags from from an event property - comma-delimited or array accepted. Will append to existing tags.")]
+            HelpText =
+                "Include tags from from an event property - comma-delimited or array accepted. Will append to existing tags.")]
         public bool AddEventTags { get; set; }
 
         //The property containing tags that can be added dynamically during runtime
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Event tag property",
-            HelpText = "The property that contains tags to include from events- defaults to 'Tags', only used if Include Event tags is enabled.")]
+            HelpText =
+                "The property that contains tags to include from events- defaults to 'Tags', only used if Include Event tags is enabled.")]
         public string AddEventProperty { get; set; }
 
-        protected override void OnAttached()
+        public void Dispose()
         {
-            _generateMessage = new HandlebarsTemplate(Host, !string.IsNullOrWhiteSpace(AlertMessage) ? AlertMessage : "{{$Message}}");
-            _generateDescription = new HandlebarsTemplate(Host, !string.IsNullOrWhiteSpace(AlertDescription) ? AlertDescription : $"Generated by Seq running at {Host.BaseUri}.");
-
-            if (!string.IsNullOrEmpty(PriorityProperty))
-                _priorityProperty = PriorityProperty;
-
-            if (!string.IsNullOrEmpty(DefaultPriority) && Enum.TryParse(DefaultPriority, true, out Priority defaultPriority))
-            {
-                _defaultPriority = defaultPriority;
-            }
-
-            if (!string.IsNullOrEmpty(EventPriority) && EventPriority.Contains("="))
-            {
-                if (TryParsePriorityMappings(EventPriority, out var mappings))
-                {
-                    _isPriorityMapping = true;
-                    foreach (var mapping in mappings)
-                        _priorities.Add(mapping.Key, mapping.Value);
-                }
-                else
-                {
-                    Log.Debug("Cannot parse priority type in Priority configuration '{Priority}' - cannot add these priority mappings. Will use default of '{DefaultPriority}'", EventPriority, _defaultPriority);
-                    _priority = _defaultPriority;
-                }
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(EventPriority) && Enum.TryParse(EventPriority, true, out Priority singlePriority))
-                {
-                    _priority = singlePriority;
-                }
-                else
-                {
-                    Log.Debug("Priority configuration '{EventPriority}' not matched - will use default of '{Priority}'", EventPriority, _defaultPriority);
-                    _priority = _defaultPriority;
-                }
-            }
-            
-            if (!string.IsNullOrEmpty(ResponderProperty))
-            {
-                _responderProperty = ResponderProperty;
-                _isResponderMapping = true;
-            }
-            
-            if (!string.IsNullOrEmpty(Responders))
-            {
-                foreach (var responder in Responders.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()))
-                {
-                    if (responder.Contains("="))
-                    {
-                        var r = responder.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()).ToArray();
-                        if (Enum.TryParse(r[1], true, out ResponderType responderType))
-                        {
-                            _responders.Add(responderType == ResponderType.User
-                                ? new Responder {Username = r[0], Type = responderType}
-                                : new Responder {Name = r[0], Type = responderType});
-                        }
-                        else
-                        {
-                            Log.Debug("Cannot parse responder type in Responder configuration '{Responder}' - cannot add this responder", responder);
-                        }
-                    }
-                    else
-                    {
-                        _responders.Add(new Responder { Name = responder, Type = ResponderType.Team });
-                    }
-                }
-            }
-
-            _tags = (Tags ?? "")
-                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(t => t.Trim())
-                .ToArray();
-
-            _includeTags = AddEventTags;
-            _includeTagProperty = "Tags";
-            if (!string.IsNullOrEmpty(AddEventProperty))
-            {
-                _includeTagProperty = AddEventProperty;
-            }
-
-            if (ApiClient == null)
-            {
-                var client = new OpsgenieApiClient(ApiKey);
-                ApiClient = client;
-                _disposeClient = client;
-            }
+            _disposeClient?.Dispose();
         }
 
         public async Task OnAsync(Event<LogEventData> evt)
@@ -200,7 +134,7 @@ namespace Seq.App.Opsgenie
             var priority = ComputePriority(evt);
             var tags = ComputeTags(evt);
             var responders = ComputeResponders(evt);
-            
+
             var alert = new OpsgenieAlert(
                 message,
                 evt.Id,
@@ -214,7 +148,7 @@ namespace Seq.App.Opsgenie
             try
             {
                 // Log our intent to alert OpsGenie with details that could be re-fired to another app if needed
-                log.ForContext("Alert", alert, destructureObjects: true)
+                log.ForContext("Alert", alert, true)
                     .Debug("Sending alert to OpsGenie API");
 
                 var result = await ApiClient.CreateAsync(alert);
@@ -227,14 +161,138 @@ namespace Seq.App.Opsgenie
             {
                 //Log an error which could be fired to another app (eg. alert via email of an OpsGenie alert failure, or raise a Jira) and include details of the alert
                 log
-                    .ForContext("Alert", alert, destructureObjects: true)
+                    .ForContext("Alert", alert, true)
                     .Error(ex, "OpsGenie alert creation failed");
             }
         }
-        
-        public void Dispose()
+
+        protected override void OnAttached()
         {
-            _disposeClient?.Dispose();
+            _generateMessage = new HandlebarsTemplate(Host,
+                !string.IsNullOrWhiteSpace(AlertMessage) ? AlertMessage : "{{$Message}}");
+            _generateDescription = new HandlebarsTemplate(Host,
+                !string.IsNullOrWhiteSpace(AlertDescription)
+                    ? AlertDescription
+                    : $"Generated by Seq running at {Host.BaseUri}.");
+
+            if (!string.IsNullOrEmpty(PriorityProperty))
+                _priorityProperty = PriorityProperty;
+
+            if (!string.IsNullOrEmpty(DefaultPriority) &&
+                Enum.TryParse(DefaultPriority, true, out Priority defaultPriority)) _defaultPriority = defaultPriority;
+
+            switch (string.IsNullOrEmpty(EventPriority))
+            {
+                case false when EventPriority.Contains("="):
+                {
+                    if (TryParsePriorityMappings(EventPriority, out var mappings))
+                    {
+                        _isPriorityMapping = true;
+                        foreach (var mapping in mappings)
+                            _priorities.Add(mapping.Key, mapping.Value);
+                        Log.ForContext("Priority", _priorities, true).Debug("Priority Mappings: {Priority}");
+                    }
+                    else
+                    {
+                        Log.ForContext("Priority", _defaultPriority).Debug(
+                            "Cannot parse priority type in Priority configuration '{EventPriority}' - cannot add these priority mappings. Will use default of '{Priority}'",
+                            EventPriority);
+                        _priority = _defaultPriority;
+                    }
+
+                    break;
+                }
+                case false when Enum.TryParse(EventPriority, true, out Priority singlePriority):
+                    _priority = singlePriority;
+                    Log.ForContext("Priority", _priority).Debug("Priority: {Priority}");
+                    break;
+                default:
+                    Log.ForContext("Priority", _defaultPriority).Debug(
+                        "Priority configuration '{EventPriority}' not matched - will use default of '{Priority}'",
+                        EventPriority);
+                    _priority = _defaultPriority;
+                    break;
+            }
+
+            //Only map responders to a property if a valid responder mapping and default responders exist
+            if (!string.IsNullOrEmpty(ResponderProperty) && !string.IsNullOrEmpty(Responders) &&
+                !string.IsNullOrEmpty(DefaultResponders))
+            {
+                _responderProperty = ResponderProperty;
+                _isResponderMapping = true;
+                Log.ForContext("ResponderProperty", _responderProperty)
+                    .Debug("Map Responder Property: {ResponderProperty}");
+            }
+            else if (!string.IsNullOrEmpty(ResponderProperty) || !string.IsNullOrEmpty(DefaultResponders))
+            {
+                Log.Debug(
+                    "Responder Property Mapping not performed, Responder Property set: {ResponderProperty}, Responders set: {Responders}, Default Responders set: {DefaultResponders}",
+                    !string.IsNullOrEmpty(ResponderProperty), !string.IsNullOrEmpty(Responders),
+                    !string.IsNullOrEmpty(DefaultResponders));
+            }
+
+            if (!string.IsNullOrEmpty(Responders))
+            {
+                foreach (var responder in Responders.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(t => t.Trim()))
+                    if (responder.Contains("="))
+                    {
+                        var r = responder.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries)
+                            .Select(t => t.Trim()).ToArray();
+                        if (Enum.TryParse(r[1], true, out ResponderType responderType))
+                            _responders.Add(responderType == ResponderType.User
+                                ? new Responder {Username = r[0], Type = responderType}
+                                : new Responder {Name = r[0], Type = responderType});
+                        else
+                            Log.Debug(
+                                "Cannot parse responder type in Responder configuration '{Responder}' - cannot add this responder",
+                                responder);
+                    }
+                    else
+                    {
+                        //Unmatched Name=Type defaults to Team
+                        _responders.Add(new Responder {Name = responder, Type = ResponderType.Team});
+                    }
+
+                Log.ForContext("Responders", _responders, true)
+                    .Debug(_isResponderMapping ? "Responder Mappings: {Responders}" : "Responders: {Responders}");
+            }
+            else
+            {
+                Log.Debug("No Responders specified, responders will not be passed to OpsGenie");
+            }
+
+            // Assign default responders where they can be matched
+            if (_isResponderMapping && !string.IsNullOrEmpty(DefaultResponders))
+            {
+                _defaultResponders.AddRange(
+                    from r in DefaultResponders.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(t => t.Trim()).ToArray()
+                    from p in _responders
+                    where r.Equals(p.Name, StringComparison.OrdinalIgnoreCase) ||
+                          r.Equals(p.Username, StringComparison.OrdinalIgnoreCase)
+                    select p);
+
+                Log.ForContext("DefaultResponders", _defaultResponders, true)
+                    .Debug("Default Responders: {DefaultResponders}");
+            }
+
+            _tags = (Tags ?? "")
+                .Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim())
+                .ToArray();
+
+            _includeTags = AddEventTags;
+            _includeTagProperty = "Tags";
+            if (!string.IsNullOrEmpty(AddEventProperty)) _includeTagProperty = AddEventProperty;
+            Log.ForContext("Tags", _tags).ForContext("IncludeTags", _includeTags)
+                .ForContext("IncludeEventTags", _includeTagProperty)
+                .Debug("Tags: {Tags}, IncludeTags: {IncludeTags}, Include Event Tags: {IncludeEventTags}");
+
+            if (ApiClient != null) return;
+            var client = new OpsgenieApiClient(ApiKey);
+            ApiClient = client;
+            _disposeClient = client;
         }
 
         private List<Responder> ComputeResponders(Event<LogEventData> evt)
@@ -245,7 +303,7 @@ namespace Seq.App.Opsgenie
             var result = new List<Responder>();
 
             //Match the Responder property if configured
-            if (!TryGetPropertyValueCI(evt.Data.Properties, _responderProperty, out var responderValue)) return result;
+            if (!TryGetPropertyValueCi(evt.Data.Properties, _responderProperty, out var responderValue)) return result;
             switch (responderValue)
             {
                 case object[] responderArr:
@@ -261,7 +319,7 @@ namespace Seq.App.Opsgenie
                             .Select(t => t.Trim()).ToArray()
                         from p in _responders
                         where r.Equals(p.Name, StringComparison.OrdinalIgnoreCase) ||
-                              r.Equals((p.Username, StringComparison.OrdinalIgnoreCase))
+                              r.Equals(p.Username, StringComparison.OrdinalIgnoreCase)
                         select p);
                     break;
                 case string responder:
@@ -275,12 +333,13 @@ namespace Seq.App.Opsgenie
                 }
             }
 
-            return result;
+            return result.Count.Equals(0) ? _defaultResponders : result;
         }
 
-        string[] ComputeTags(Event<LogEventData> evt)
+        private string[] ComputeTags(Event<LogEventData> evt)
         {
-            if (!_includeTags || !TryGetPropertyValueCI(evt.Data.Properties, _includeTagProperty, out var tagArrValue) ||
+            if (!_includeTags ||
+                !TryGetPropertyValueCi(evt.Data.Properties, _includeTagProperty, out var tagArrValue) ||
                 !(tagArrValue is object[] tagArr))
                 return _tags;
 
@@ -289,8 +348,8 @@ namespace Seq.App.Opsgenie
             {
                 if (!(p is string tags))
                     continue;
-                
-                result.UnionWith(tags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()));
+
+                result.UnionWith(tags.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()));
             }
 
             return result.ToArray();
@@ -300,24 +359,21 @@ namespace Seq.App.Opsgenie
         {
             if (!_isPriorityMapping)
                 return _priority;
-            
+
             if (_priorityProperty.Equals("@Level", StringComparison.OrdinalIgnoreCase) &&
                 _priorities.TryGetValue(evt.Data.Level.ToString(), out var matched))
-            {
                 return matched;
-            }
-            
-            if (TryGetPropertyValueCI(evt.Data.Properties, _priorityProperty, out var priorityProperty) &&
+
+            if (TryGetPropertyValueCi(evt.Data.Properties, _priorityProperty, out var priorityProperty) &&
                 priorityProperty is string priorityValue &&
                 _priorities.TryGetValue(priorityValue, out var matchedPriority))
-            {
                 return matchedPriority;
-            }
 
             return _defaultPriority;
         }
 
-        internal static bool TryGetPropertyValueCI(IReadOnlyDictionary<string,object> properties, string propertyName, out object propertyValue)
+        internal static bool TryGetPropertyValueCi(IReadOnlyDictionary<string, object> properties, string propertyName,
+            out object propertyValue)
         {
             var pair = properties.FirstOrDefault(p => p.Key.Equals(propertyName, StringComparison.OrdinalIgnoreCase));
             if (pair.Key == null)
@@ -338,11 +394,8 @@ namespace Seq.App.Opsgenie
             foreach (var pair in pairs)
             {
                 var kv = pair.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
-                if (kv.Length != 2 || !Enum.TryParse(kv[1], true, out Priority value))
-                {
-                    return false;
-                }
-                
+                if (kv.Length != 2 || !Enum.TryParse(kv[1], true, out Priority value)) return false;
+
                 mappings.Add(kv[0].Trim(), value);
             }
 

--- a/test/Seq.App.Opsgenie.Tests/OpsgenieAppTests.cs
+++ b/test/Seq.App.Opsgenie.Tests/OpsgenieAppTests.cs
@@ -51,13 +51,13 @@ namespace Seq.App.Opsgenie.Tests
                 ["b"] = new { }
             };
             
-            Assert.True(OpsgenieApp.TryGetPropertyValueCI(properties, "A", out var actual));
+            Assert.True(OpsgenieApp.TryGetPropertyValueCi(properties, "A", out var actual));
             Assert.Equal(expected, actual);
 
-            Assert.True(OpsgenieApp.TryGetPropertyValueCI(properties, "a", out actual));
+            Assert.True(OpsgenieApp.TryGetPropertyValueCi(properties, "a", out actual));
             Assert.Equal(expected, actual);
             
-            Assert.False(OpsgenieApp.TryGetPropertyValueCI(properties, "C", out _));
+            Assert.False(OpsgenieApp.TryGetPropertyValueCi(properties, "C", out _));
         }
 
         [Theory]


### PR DESCRIPTION
Hi @nblumhardt,

Followon to #6, adding the default responders property as mentioned in my last comment. Enabling mapping of a responder property is now conditional on ResponderProperty, Responder, and Default Responder being configured.

Further to this, I noted and fixed a suspicious comparison that I'd created in #6 for the ComputerResponders. Stray brackets...

As we have add some complexity to the config with the new properties and especially property mappings, I have added debug logging so that the outcome of these configurations can be derived from the logs. This should help with pinpointing misconfigurations or unexpected behaviours.

I also ran OpsGenieApp through a code cleanup and took a couple of code usage opportunities (eg. using switch statements, etc). TryGetPropertyValueCI was renamed for the sake of a constraints violation.

Resulting changes look like more than they are as a result of methods being reordered - apologies.

Cheers,

Matt