### PR TITLE
Update description to InputType.LongText

### DIFF
--- a/src/Seq.App.Opsgenie/OpsgenieApp.cs
+++ b/src/Seq.App.Opsgenie/OpsgenieApp.cs
@@ -49,6 +49,7 @@ namespace Seq.App.Opsgenie
         [SeqAppSetting(
             IsOptional = true,
             DisplayName = "Alert description",
+            InputType = SettingInputType.LongText,
             HelpText =
                 "The description associated with the alert, specified with Handlebars syntax. If blank, a default" +
                 " description will be used.")]

--- a/src/Seq.App.Opsgenie/Seq.App.Opsgenie.csproj
+++ b/src/Seq.App.Opsgenie/Seq.App.Opsgenie.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="Handlebars.Net" Version="2.0.8" />
+      <PackageReference Include="Handlebars.Net" Version="2.0.9" />
       <PackageReference Include="Seq.Apps" Version="5.1.0" />
       <PackageReference Include="system.text.json" Version="5.0.2" />
     </ItemGroup>


### PR DESCRIPTION
Hey @nblumhardt ,

I'll have to do PIV testing to double check that this works with the Opsgenie REST API, but when integrating Handlebars.NET to Seq.App.Atlassian.Jira, I noted that the Jira REST API integration worked better (in terms of formatting) if I pivoted the Description field to an InputType.LongText.  Prior to that, functionality like headers and tables were problematic in the InputType.Text constraints, thanks to some of the interaction between Seq, the Jira app, and the Jira REST API.

Obviously the other benefit of this is that it's easier to see and edit the Handlebars template for description, which can potentially be quite long. 

I've blogged about how Handlebars can be used with the Jira (and Opsgenie) apps and how truly useful it is at https://mattmofdoom.com/using-handlebars-templates-with-seqappatlassianjira-and-seqappopsgenie/ 

I took an earlier pass at whether there was anything else that could usefully be added to the OpsGenie app from all the interoperability work of late, but I think we're more or less getting to the feature complete stage for that v1.0 PR you have flagged 😁

Cheers mate,

Matt
